### PR TITLE
on refresh CentOS release 6.4 (Final), Time::HiRes is not installed by default.

### DIFF
--- a/t/80threadbomb.t
+++ b/t/80threadbomb.t
@@ -11,7 +11,7 @@ BEGIN {
 
 eval "use Time::HiRes qw(sleep);";
 if ($@) {
-    print "1..0 # Time::HiRes required for testing.\n";
+    print "1..0 # SKIP Time::HiRes is required for this testing.\n";
     exit(0);
 }
 


### PR DESCRIPTION
on refresh CentOS release 6.4 (Final), Time::HiRes is not installed by default.

t/80threadbomb.t .............. Can't locate Time/HiRes.pm in @INC (@INC contains: /root/.cpanm/work/1385001106.28911/Class-XSAccessor-1.18/blib/lib /root/.cpanm/work/1385001106.28911/Class-XSAccessor-1.18/blib/arch /usr/local/lib64/perl5 /usr/local/share/perl5 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5 .) at t/80threadbomb.t line 57.
BEGIN failed--compilation aborted at t/80threadbomb.t line 57.
t/80threadbomb.t .............. Dubious, test returned 2 (wstat 512, 0x200)
