### PR TITLE
Add support for lazy builders

### DIFF
--- a/XS/Hash.xs
+++ b/XS/Hash.xs
@@ -431,9 +431,9 @@ newxs_setter(namesv, keysv, chained)
     }
     else if (ix == 1) { /* newxs_accessor */
       if (chained)
-        INSTALL_NEW_CV_HASH_OBJ(name, CXAH(chained_setter), key, keylen);
+        INSTALL_NEW_CV_HASH_OBJ(name, CXAH(chained_accessor), key, keylen);
       else
-        INSTALL_NEW_CV_HASH_OBJ(name, CXAH(setter), key, keylen);
+        INSTALL_NEW_CV_HASH_OBJ(name, CXAH(accessor), key, keylen);
     }
     else { /* newxs_lzaccessor */
       if (chained)

--- a/XSAccessor.xs
+++ b/XSAccessor.xs
@@ -399,6 +399,8 @@ CXA_Setup_Xsub_Hash(constant_false);
 CXA_Setup_Xsub_Hash(constant_true);
 CXA_Setup_Xsub_Hash(defined_predicate);
 CXA_Setup_Xsub_Hash(exists_predicate);
+CXA_Setup_Xsub_Hash(lzgetter);
+CXA_Setup_Xsub_Hash(lzaccessor);
 
 /* special case for test function */
 XS(CXAH(test));

--- a/t/11hash_lazy.t
+++ b/t/11hash_lazy.t
@@ -1,0 +1,59 @@
+use strict;
+use warnings;
+
+package Class::XSAccessor::Test;
+use Class::XSAccessor
+  lazy_accessors      => { bar => 'bar' },
+  lazy_getters        => { get_foo => 'foo' };
+sub new {
+  my $class = shift;
+  bless { @_ }, $class;
+}
+sub _build_foo {
+  my $self = shift;
+  return ref($self) ? 111 : 333;
+}
+sub _build_bar {
+  my $self = shift;
+  return wantarray ? 444 : 222;
+}
+sub _build_get_foo {
+  die "This should never be called.";
+}
+
+package Class::XSAccessor::TestChained;
+our @ISA = 'Class::XSAccessor::Test';
+use Class::XSAccessor
+  chained             => 1,
+  lazy_accessors      => { bar => 'bar' },
+  lazy_getters        => { get_foo => 'foo' };
+
+package main;
+use Test::More tests => 18;
+
+my $t1 = Class::XSAccessor::Test->new( foo => 42, bar => 43 );
+is( $t1->get_foo, 42 );
+is( $t1->bar, 43 );
+
+my $t2 = Class::XSAccessor::Test->new;
+ok( !exists $t2->{foo} );
+is( $t2->get_foo, 111 );
+is( $t2->{foo}, 111 );
+ok( !exists $t2->{bar} );
+is( $t2->bar, 222 );
+is( $t2->{bar}, 222 );
+ok !eval { $t2->get_foo(333); 1 };
+
+my $t3 = Class::XSAccessor::Test->new( foo => undef, bar => undef );
+is( $t3->get_foo, undef );
+is( $t3->bar, undef );
+ok( !defined $t3->{bar} );
+delete $t3->{bar};
+ok( !exists $t3->{bar} );
+is( $t3->bar, 222 );
+is( $t3->{bar}, 222 );
+
+my $t4 = Class::XSAccessor::TestChained->new( foo => 42, bar => 43 );
+is( $t4->get_foo, 42 );
+is( $t4->bar, 43 );
+is( $t4->bar(55), $t4 );


### PR DESCRIPTION
This commit adds support for lazy builders:

```perl
use v5.12;

package Foo {
  use Class::XSAccessor
    constructor  => 'new',
    lazy_getters => { get_bar => 'bar' };

  sub _build_bar {
    my $self = shift;
    return 'iron bar';
  }
}

my $foo1 = Foo->new( bar => 'chocolate bar' );
say $foo1->get_bar;   # chocolate bar

my $foo2 = Foo->new;
say $foo2->get_bar;   # iron bar
```

When the lazy getter is called, if the hash key does not exist, a method called "_build_$slot" will be called to return a default value. This will be stored in the hash and then the getter will continue as normal.

Also `lazy_accessors` is supported, including support for `chained => 1`.

I think this patch could be very helpful for accelerating Moo-based code which tries to use Class::XSAccessor when possible, but currently cannot for any lazy-built attributes.

Dancer2 in particular makes heavy use of lazy-built attributes, so this patch has the potential to eventually speed up Dancer2-based websites.